### PR TITLE
fix(sandbox): fix docker-compose bring-up, Node-RED palette, and I/O Tags UI

### DIFF
--- a/sandbox/core/oso_core.py
+++ b/sandbox/core/oso_core.py
@@ -12,6 +12,7 @@
 #
 # (C) 2026 Roig Borrell S.L. · Ibercomp S.L. — AGPL-3.0-or-later
 # ============================================================
+import base64
 import glob
 import json
 import math
@@ -21,6 +22,7 @@ import shutil
 import hashlib
 import re
 import socket
+import struct
 import urllib.request
 import subprocess
 import tempfile
@@ -29,7 +31,7 @@ import time
 from collections import deque
 from concurrent.futures import ThreadPoolExecutor
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from urllib.parse import parse_qs, unquote
+from urllib.parse import parse_qs, unquote, urlparse
 
 try:
     import pymysql
@@ -177,11 +179,19 @@ def eval_alarms():
             ALARM_ACTIVE[rid]["value"] = r.get("value")
 
 
+def tag_group(tid):
+    """Derive a sidebar group from the tag id: 'hass.switch.pump' -> 'hass.switch', '2.1' -> '2'."""
+    parts = tid.split(".")
+    return ".".join(parts[:-1]) if len(parts) > 1 else parts[0]
+
+
 def tag_pub(r):
     """Public tag shape for REST (works for /tags and /api/v1/tags — includes `type` alias)."""
+    ts = r.get("_ts")
     return {"id": r["id"], "name": r.get("name"), "data_type": r.get("data_type"),
             "type": r.get("data_type"), "value": tag_value(r), "units": r.get("units"),
-            "access": r.get("access")}
+            "access": r.get("access"), "group": tag_group(r["id"]),
+            "ts_us": int(ts * 1_000_000) if ts else None}
 
 
 # ---- DB -----------------------------------------------------
@@ -256,8 +266,10 @@ def scan_loop():
         _noise = _sp.get("noise") or 0.0
         _sine, _ramp = _sp["sine"], _sp["ramp"]
         _sim_on = OSO_RUNTIME["mode"] == "simulation"   # soft-PLC mode: real I/O, no fabrication
+        changed = []
         for tid, r in list(CACHE.items()):
             sim = r.get("sim")
+            before = r.get("value")
             if sim == "follow" and r.get("required_value") is not None:
                 r["value"] = r["required_value"]        # control (set-point) — both modes
             elif _sim_on and sim == "sine":
@@ -271,12 +283,17 @@ def scan_loop():
                 per = _ramp["period_s"] or 20.0
                 r["value"] = round(_ramp["base"] + _ramp["span"] * ((t / per) % 1)
                                    + (random.uniform(-_noise, _noise) if _noise else 0), 2)
+            if r.get("value") != before:
+                r["_ts"] = time.time()
+                changed.append({"id": tid, "value": tag_value(r), "ts_us": int(r["_ts"] * 1_000_000)})
             # persist current value back to the DB (source of truth)
             if _conn:
                 try:
                     db_exec("UPDATE tags SET value=%s WHERE id=%s", (float(r["value"] or 0), tid))
                 except Exception:
                     pass
+        if changed:
+            ws_broadcast({"type": "tag_batch", "updates": changed})
         try:
             eval_alarms()
         except Exception:
@@ -915,12 +932,13 @@ def _db_test(bid, dsn):
             con.close()
             return {"ok": True, "note": f"{bid}: opened and queried OK"}
         if bid in ("postgres", "mariadb"):
-            host, port = "127.0.0.1", (5432 if bid == "postgres" else 3306)
-            for tok in dsn.replace("//", " ").replace("/", " ").replace("@", " ").replace("=", " ").split():
-                if tok.count(".") == 3:
-                    host = tok
-                if tok.isdigit():
-                    port = int(tok)
+            default_port = 5432 if bid == "postgres" else 3306
+            if "://" in dsn:
+                u = urlparse(dsn)
+                host, port = u.hostname or "127.0.0.1", u.port or default_port
+            else:
+                kv = dict(tok.split("=", 1) for tok in dsn.split() if "=" in tok)
+                host, port = kv.get("host", "127.0.0.1"), int(kv.get("port", default_port))
             s = socket.create_connection((host, port), timeout=3)
             s.close()
             return {"ok": True, "note": f"{bid}: reachable at {host}:{port}"}
@@ -1502,6 +1520,66 @@ def scan_tcp(subnet, ports_str):
     return {"subnet": base + ".0/24", "scanned_ports": plist, "hosts": hosts}
 
 
+# ---- WebSocket (live tag push for the I/O Tags UI) ----------
+# Minimal RFC 6455 server: no external deps, so it lives right on top of the
+# stdlib HTTP handler's raw socket. One client = one dedicated thread blocked
+# in _ws_upgrade() (ThreadingHTTPServer already gives every connection its own
+# thread, so this doesn't cost anything extra).
+WS_MAGIC = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+WS_CLIENTS = set()
+WS_LOCK = threading.Lock()
+
+
+def _ws_accept_key(key):
+    return base64.b64encode(hashlib.sha1((key + WS_MAGIC).encode()).digest()).decode()
+
+
+def _ws_send(conn, payload, opcode=0x1):
+    length = len(payload)
+    if length < 126:
+        header = bytes([0x80 | opcode, length])
+    elif length < 65536:
+        header = bytes([0x80 | opcode, 126]) + struct.pack(">H", length)
+    else:
+        header = bytes([0x80 | opcode, 127]) + struct.pack(">Q", length)
+    try:
+        conn.sendall(header + payload)
+        return True
+    except Exception:
+        return False
+
+
+def _ws_recv_frame(rfile):
+    """Read one client→server frame (client frames are always masked). None on close/error."""
+    hdr = rfile.read(2)
+    if len(hdr) < 2:
+        return None
+    opcode = hdr[0] & 0x0F
+    masked = hdr[1] & 0x80
+    length = hdr[1] & 0x7F
+    if length == 126:
+        length = struct.unpack(">H", rfile.read(2))[0]
+    elif length == 127:
+        length = struct.unpack(">Q", rfile.read(8))[0]
+    mask = rfile.read(4) if masked else None
+    data = rfile.read(length) if length else b""
+    if mask:
+        data = bytes(b ^ mask[i % 4] for i, b in enumerate(data))
+    return opcode, data
+
+
+def ws_broadcast(msg):
+    if not WS_CLIENTS:
+        return
+    payload = json.dumps(msg).encode()
+    with WS_LOCK:
+        clients = list(WS_CLIENTS)
+    dead = [c for c in clients if not _ws_send(c, payload)]
+    if dead:
+        with WS_LOCK:
+            WS_CLIENTS.difference_update(dead)
+
+
 # ---- REST + static -----------------------------------------
 class Handler(BaseHTTPRequestHandler):
     def log_message(self, *a):
@@ -1524,8 +1602,40 @@ class Handler(BaseHTTPRequestHandler):
     def do_OPTIONS(self):
         self.send_response(204); self._cors(); self.end_headers()
 
+    def _ws_upgrade(self):
+        key = self.headers.get("Sec-WebSocket-Key")
+        if not key or self.headers.get("Upgrade", "").lower() != "websocket":
+            return self._json({"error": "expected websocket upgrade"}, 400)
+        resp = ("HTTP/1.1 101 Switching Protocols\r\n"
+                "Upgrade: websocket\r\nConnection: Upgrade\r\n"
+                f"Sec-WebSocket-Accept: {_ws_accept_key(key)}\r\n\r\n")
+        conn = self.connection
+        conn.sendall(resp.encode())
+        with WS_LOCK:
+            WS_CLIENTS.add(conn)
+        try:
+            while True:
+                frame = _ws_recv_frame(self.rfile)
+                if frame is None:
+                    break
+                opcode, data = frame
+                if opcode == 0x8:                      # close
+                    break
+                if opcode == 0x9:                       # ping -> pong
+                    _ws_send(conn, data, opcode=0xA)
+                # 0x1 text (e.g. the client's initial {"type":"subscribe",...}) — no action needed;
+                # every change is broadcast to every connected client already.
+        except Exception:
+            pass
+        finally:
+            with WS_LOCK:
+                WS_CLIENTS.discard(conn)
+            self.close_connection = True
+
     def do_GET(self):
         path = self.path.split("?", 1)[0]
+        if path == "/ws":
+            return self._ws_upgrade()
         if path in ("/tags", "/api/tags", "/api/v1/tags"):
             return self._json([tag_pub(r) for r in CACHE.values()])
         if path == "/api/v1/runtime":
@@ -1962,9 +2072,13 @@ class Handler(BaseHTTPRequestHandler):
         except Exception:
             num = 1.0 if str(val).lower() in ("1", "true", "on") else 0.0
         r["required_value"] = num
+        if r.get("sim") == "follow":
+            r["value"] = num          # sandbox actuator "follows" the set-point immediately
+        r["_ts"] = time.time()
         db_exec("UPDATE tags SET required_value=%s WHERE id=%s", (num, key))
         log("info", f"set-point {key} = {num}")
-        return self._json({"id": key, "required_value": num, "ok": True})
+        ws_broadcast({"type": "tag_update", "id": key, "value": tag_value(r), "ts_us": int(r["_ts"] * 1_000_000)})
+        return self._json({**tag_pub(r), "ok": True})
 
     def _static(self, path):
         if path in ("/", ""):

--- a/sandbox/docker-compose.yml
+++ b/sandbox/docker-compose.yml
@@ -1,6 +1,5 @@
 # OSOLogic sandbox — one command, same result on Linux, Windows (Docker Desktop / WSL2) and macOS.
-#   docker compose up --build      → UI+REST http://localhost:8080 · OPC-UA opc.tcp://localhost:4840 · DB :3306
-# TODO: FIX ERRORS
+#   docker compose up --build      → UI+REST http://localhost:8080 · OPC-UA opc.tcp://localhost:4840 · DB :3307
 name: osologic-sandbox
 services:
   db:
@@ -12,7 +11,7 @@ services:
       - ./db/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
       - osodb-data:/var/lib/mysql
     ports:
-      - "3306:3306"          # control the plant with plain SQL from anywhere
+      - "3307:3306"          # control the plant with plain SQL from anywhere (host :3307 — :3306 inside the container to avoid conflicts with a host MySQL/MariaDB)
     healthcheck:
       test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
       interval: 5s
@@ -31,8 +30,10 @@ services:
       - "8080:8080"          # web UI + REST API
       - "4840:4840"          # OPC-UA server
     volumes:
-      - ../:/repo:ro                         # serve the whole frontend (ui/ + iec61131/ editors)
-      - ./web/index.html:/repo/index.html:ro # sandbox landing page
+      # Serve the whole frontend (ui/ + iec61131/ editors). The sandbox landing page
+      # rides along inside this mount (sandbox/web/index.html) and oso_core picks it
+      # up at "/" — no nested bind mount, which runc cannot create inside a :ro mount.
+      - ../:/repo:ro
     depends_on:
       db:
         condition: service_healthy
@@ -45,7 +46,7 @@ services:
   # manual Manage-Palette/import steps. The MySQL config node targets host "db",
   # database "osodb".
   nodered:
-    image: nodered/node-red:4
+    image: nodered/node-red:4.1   # the bare "4" tag no longer exists upstream — pin the 4.x line
     ports:
       - "1880:1880"
     environment:

--- a/ui/node-red/package.json
+++ b/ui/node-red/package.json
@@ -3,7 +3,11 @@
     "description": "A Node-RED Project",
     "version": "0.0.1",
     "dependencies": {
-        "node-red-contrib-mysql-config": "1.0.4"
+        "node-red-contrib-mysql-config": "1.0.4",
+        "node-red-node-mysql": "3.0.3",
+        "node-red-contrib-mysql2": "0.2.0",
+        "node-red-node-email": "5.2.5",
+        "node-red-contrib-telegrambot": "18.1.1"
     },
     "node-red": {
         "settings": {

--- a/ui/webmin-oso/cockpit/oso-iotags/index.html
+++ b/ui/webmin-oso/cockpit/oso-iotags/index.html
@@ -62,6 +62,7 @@
   .bool-toggle:disabled{opacity:.5;cursor:default}
   .btn-edit,.btn-ok,.btn-x{background:var(--panel-2);border:1px solid var(--line);color:var(--muted);border-radius:6px;padding:3px 9px;cursor:pointer;font-size:12px}
   .btn-edit:hover{border-color:var(--accent);color:var(--accent)}
+  .ro-lock{font-size:11px;opacity:.45;cursor:default}
   .btn-ok:hover{border-color:var(--good);color:var(--good)}
   .btn-x:hover{border-color:var(--bad);color:var(--bad)}
   .empty{text-align:center;color:var(--muted);padding:26px}
@@ -99,16 +100,6 @@
       <input type="text" id="searchInput" placeholder="Search tags…" oninput="applyFilters()">
       <select class="type-filter" id="typeFilter" onchange="applyFilters()">
         <option value="">All types</option>
-        <option>BOOL</option>
-        <option>INT</option>
-        <option>DINT</option>
-        <option>LINT</option>
-        <option>REAL</option>
-        <option>LREAL</option>
-        <option>WORD</option>
-        <option>DWORD</option>
-        <option>STRING</option>
-        <option>TIME</option>
       </select>
       <button class="toggle-btn" id="changedBtn" onclick="toggleChangedOnly()">Changed only</button>
       <div class="toolbar-right">
@@ -142,15 +133,23 @@
 const BASE = '/api/v1';
 const WS_URL = `ws://${location.host}/ws`;
 
+// osodb's data_type is coarse (Boolean/Int/Float/String); map it to the IEC 61131
+// type names used across the rest of OSOlogic (iec61131/st editors etc.) for display/filtering.
+const IEC_TYPE = { Boolean: 'BOOL', Int: 'INT', Float: 'REAL', String: 'STRING' };
+function iecType(t) { return IEC_TYPE[t.type] || t.type; }
+
 // ── State ──────────────────────────────────────────────────
 let allTags     = {};       // id → tag
 let groups      = new Set();
+let types       = new Set();
 let activeGroup = null;     // null = all
 let sortKey     = 'name';
 let sortDir     = 1;        // 1 asc, -1 desc
 let changedOnly = false;
 let recentIds   = new Set(); // tags updated in last 5s
+let recentTimers = {};       // id → expiry timer, so repeat updates extend the window
 let editingId   = null;
+let editPending = null;      // Boolean tags: toggled state not yet saved (mirrors the numeric input)
 let ws          = null;
 
 // ── Boot ───────────────────────────────────────────────────
@@ -173,11 +172,14 @@ async function fetchTags() {
     const list = await api('GET', '/tags');
     allTags = {};
     groups = new Set(['(all)']);
+    types = new Set();
     list.forEach(t => {
       allTags[t.id] = t;
       if (t.group) groups.add(t.group);
+      if (t.type) types.add(iecType(t));
     });
     renderGroups();
+    renderTypeFilter();
     applyFilters();
     document.getElementById('tagSummary').textContent =
       `${list.length} tags · ${groups.size - 1} groups`;
@@ -195,11 +197,18 @@ function renderGroups() {
         ? Object.keys(allTags).length
         : Object.values(allTags).filter(t => t.group === g).length;
       return `<div class="group-item${activeGroup === g || (g==='(all)' && !activeGroup) ? ' active' : ''}"
-                   onclick="selectGroup(${JSON.stringify(g)})">
-        <span>${g}</span>
+                   onclick="selectGroup(${jsArg(g)})">
+        <span>${esc(g)}</span>
         <span class="group-count">${count}</span>
       </div>`;
     }).join('');
+}
+
+function renderTypeFilter() {
+  const el = document.getElementById('typeFilter');
+  const cur = el.value;
+  el.innerHTML = '<option value="">All types</option>' +
+    [...types].sort().map(t => `<option${t === cur ? ' selected' : ''}>${esc(t)}</option>`).join('');
 }
 
 function selectGroup(g) {
@@ -215,10 +224,11 @@ function applyFilters() {
 
   let list = Object.values(allTags).filter(t => {
     if (activeGroup && t.group !== activeGroup) return false;
-    if (type && t.type !== type) return false;
+    if (type && iecType(t) !== type) return false;
     if (changedOnly && !recentIds.has(t.id)) return false;
     if (search && !t.name.toLowerCase().includes(search) &&
-                  !(t.group||'').toLowerCase().includes(search)) return false;
+                  !(t.group||'').toLowerCase().includes(search) &&
+                  !String(t.id).toLowerCase().includes(search)) return false;
     return true;
   });
 
@@ -271,13 +281,16 @@ function renderTable(list) {
 function renderViewRow(t, now) {
   const valHtml = renderValue(t);
   const age = t.ts_us != null ? fmtAge(now - Math.floor(t.ts_us / 1000)) : '—';
-  const editBtn = t.read_only ? '' :
-    `<button class="btn-edit" onclick="startEdit(${t.id})">✎</button>`;
+  // Read-only tags (sensors) are rejected by the API with 403, so they get a lock
+  // instead of a pencil — the gap in the column is intentional, not a missing button.
+  const editBtn = t.access === 'ReadOnly'
+    ? `<span class="ro-lock" title="Read-only tag">🔒</span>`
+    : `<button class="btn-edit" onclick="startEdit(${jsArg(t.id)})">✎</button>`;
   const flash = recentIds.has(t.id) ? ' class="flash"' : '';
-  return `<tr id="row-${t.id}"${flash}>
+  return `<tr id="row-${esc(t.id)}"${flash}>
     <td class="td-name">${esc(t.name)}</td>
     <td class="td-group">${esc(t.group||'')}</td>
-    <td><span class="td-type">${t.type}</span></td>
+    <td><span class="td-type">${iecType(t)}</span></td>
     <td>${valHtml}</td>
     <td class="td-age">${age}</td>
     <td>${editBtn}</td>
@@ -285,49 +298,79 @@ function renderViewRow(t, now) {
 }
 
 function renderEditRow(t) {
-  const cur = t.type === 'BOOL'
-    ? `<button class="bool-toggle${t.value ? ' on' : ''}" onclick="writeTag(${t.id}, ${!t.value})"></button>`
-    : `<input class="val-input" id="editInput" value="${esc(String(t.value??''))}"
-         onkeydown="if(event.key==='Enter')commitEdit(${t.id});if(event.key==='Escape')cancelEdit()">
-       <button class="btn-ok" onclick="commitEdit(${t.id})">✓</button>
+  const idArg = jsArg(t.id);
+  // Boolean: the toggle only flips a local pending state (toggleEditPending) — nothing is
+  // written until ✓, same as the numeric input below.
+  const cur = t.type === 'Boolean'
+    ? `<button class="bool-toggle${editPending ? ' on' : ''}" onclick="toggleEditPending()"></button>
+       <button class="btn-ok" onclick="commitEdit(${idArg})">✓</button>
+       <button class="btn-x"  onclick="cancelEdit()">✕</button>`
+    : `<input class="val-input" id="editInput" value="${esc(fmtTagValue(t))}"
+         onkeydown="if(event.key==='Enter')commitEdit(${idArg});if(event.key==='Escape')cancelEdit()">
+       <button class="btn-ok" onclick="commitEdit(${idArg})">✓</button>
        <button class="btn-x"  onclick="cancelEdit()">✕</button>`;
-  return `<tr id="row-${t.id}">
+  return `<tr id="row-${esc(t.id)}">
     <td class="td-name">${esc(t.name)}</td>
     <td class="td-group">${esc(t.group||'')}</td>
-    <td><span class="td-type">${t.type}</span></td>
+    <td><span class="td-type">${iecType(t)}</span></td>
     <td><div class="val-wrap">${cur}</div></td>
     <td></td><td></td>
   </tr>`;
 }
 
 function renderValue(t) {
-  if (t.type === 'BOOL') {
+  if (t.type === 'Boolean') {
+    // View mode is read-only for booleans too — the toggle only becomes interactive
+    // inside renderEditRow(), reached via the pencil. Always disabled here (greyed by
+    // the existing .bool-toggle:disabled CSS), regardless of the tag's access.
     return `<div class="val-wrap">
-      <button class="bool-toggle${t.value ? ' on' : ''}" ${t.read_only ? 'disabled' : `onclick="writeTag(${t.id}, ${!t.value})"`}></button>
+      <button class="bool-toggle${t.value ? ' on' : ''}" disabled></button>
       <span class="val-text ${t.value ? 'val-true' : 'val-false'}">${t.value ? 'TRUE' : 'FALSE'}</span>
     </div>`;
   }
-  const isNum = ['INT','DINT','LINT','SINT','BYTE','WORD','DWORD','LWORD','REAL','LREAL'].includes(t.type);
-  const cls = isNum ? 'val-num' : t.type === 'STRING' ? 'val-str' : 'val-text';
-  const unit = t.unit ? `<span style="color:#555;font-size:11px;margin-left:4px">${esc(t.unit)}</span>` : '';
-  return `<span class="val-text ${cls}">${esc(String(t.value ?? '—'))}</span>${unit}`;
+  const isNum = ['Int','Float'].includes(t.type);
+  const cls = isNum ? 'val-num' : t.type === 'String' ? 'val-str' : 'val-text';
+  const unit = t.units ? `<span style="color:#555;font-size:11px;margin-left:4px">${esc(t.units)}</span>` : '';
+  return `<span class="val-text ${cls}">${esc(fmtTagValue(t))}</span>${unit}`;
+}
+
+// REAL/Float always reads as a decimal (3 -> "3.0") — JS drops the trailing ".0" on
+// integer-valued numbers by default, which makes a REAL look like an INT in the table.
+function fmtTagValue(t) {
+  if (t.value == null) return '—';
+  if (t.type === 'Float') {
+    const n = Number(t.value);
+    return Number.isInteger(n) ? n.toFixed(1) : String(n);
+  }
+  return String(t.value);
 }
 
 // ── Inline edit ────────────────────────────────────────────
 function startEdit(id) {
   editingId = id;
+  editPending = allTags[id].type === 'Boolean' ? !!allTags[id].value : null;
   applyFilters();
   // Focus input on next tick
-  if (allTags[id].type !== 'BOOL')
+  if (allTags[id].type !== 'Boolean')
     setTimeout(() => document.getElementById('editInput')?.focus(), 20);
 }
 
 function cancelEdit() {
   editingId = null;
+  editPending = null;
+  applyFilters();
+}
+
+function toggleEditPending() {
+  editPending = !editPending;
   applyFilters();
 }
 
 async function commitEdit(id) {
+  if (allTags[id]?.type === 'Boolean') {
+    await writeTag(id, editPending);
+    return;
+  }
   const input = document.getElementById('editInput');
   if (!input) return;
   const raw = input.value.trim();
@@ -338,9 +381,9 @@ async function writeTag(id, rawValue) {
   const t = allTags[id];
   if (!t) return;
   let value;
-  if (t.type === 'BOOL') value = Boolean(rawValue);
-  else if (['INT','DINT','LINT','SINT','BYTE','WORD','DWORD','LWORD'].includes(t.type)) value = parseInt(rawValue, 10);
-  else if (['REAL','LREAL'].includes(t.type)) value = parseFloat(rawValue);
+  if (t.type === 'Boolean') value = Boolean(rawValue);
+  else if (t.type === 'Int') value = parseInt(rawValue, 10);
+  else if (t.type === 'Float') value = parseFloat(rawValue);
   else value = rawValue;
 
   try {
@@ -350,6 +393,7 @@ async function writeTag(id, rawValue) {
     console.error('Write failed', e);
   }
   editingId = null;
+  editPending = null;
   applyFilters();
 }
 
@@ -372,19 +416,30 @@ function connectWS() {
 }
 
 function handleMsg(msg) {
-  const apply = (name, value, ts_us) => {
-    const t = Object.values(allTags).find(x => x.name === name);
+  let entered = false;   // a tag became "recent" that the current filter wasn't showing
+  const apply = (id, value, ts_us) => {
+    const t = allTags[id];
     if (!t) return;
     t.value = value;
     t.ts_us = ts_us;
+    if (!recentIds.has(t.id)) entered = true;
     recentIds.add(t.id);
-    setTimeout(() => { recentIds.delete(t.id); }, 5000);
+    clearTimeout(recentTimers[t.id]);
+    recentTimers[t.id] = setTimeout(() => {
+      recentIds.delete(t.id);
+      delete recentTimers[t.id];
+      if (changedOnly) applyFilters();   // it dropped out of "Changed only" — re-render
+    }, 5000);
     // Update row in-place without full re-render
     updateRow(t);
   };
 
-  if (msg.type === 'tag_update') apply(msg.tag, msg.value, msg.ts_us);
-  else if (msg.type === 'tag_batch') (msg.updates||[]).forEach(u => apply(u.tag, u.value, u.ts_us));
+  if (msg.type === 'tag_update') apply(msg.id, msg.value, msg.ts_us);
+  else if (msg.type === 'tag_batch') (msg.updates||[]).forEach(u => apply(u.id, u.value, u.ts_us));
+
+  // "Changed only" shows a set that grows as updates arrive, so a tag entering it needs a
+  // real re-render — updateRow() alone can only patch rows the last render already drew.
+  if (entered && changedOnly) applyFilters();
 }
 
 function updateRow(t) {
@@ -408,6 +463,10 @@ function fmtAge(ms) {
 function esc(s) {
   return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
 }
+// A JS string literal safe to inline inside a double-quoted HTML attribute: tag ids and
+// groups are text ("hass.switch.pump"), so the quotes must survive as &quot; entities —
+// a raw JSON.stringify would terminate the attribute at its first ".
+function jsArg(s) { return esc(JSON.stringify(String(s))); }
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- `docker compose up --build` failed out of the box: `nodered/node-red:4` no longer
  resolves upstream, and a nested `:ro` bind mount for the landing page couldn't be
  created by runc. Also mapped the DB to host `:3307` to avoid the very common
  conflict with a local MySQL/MariaDB already on `:3306`.
- Node-RED's reference `flows.json` uses node types (`mysql2-server`, `MySQLdatabase`,
  `mysql`, `e-mail`, `telegram bot`, `telegram sender`) that were never declared in
  `ui/node-red/package.json`, so `seed.sh` never installed them and Node-RED opened
  with "Flows stopped due to missing node type".
- The I/O Tags admin page (`ui/webmin-oso/cockpit/oso-iotags`) had no live updates
  (no WebSocket endpoint existed on the core), no tag grouping, no "Updated" column,
  a broken edit pencil / group sidebar for any tag id containing a dot (HTML
  attribute built with raw `JSON.stringify`), a type filter that never matched
  anything (hardcoded IEC names vs. the API's actual `data_type` strings), and a
  boolean toggle that wrote on every click instead of staging until confirmed.
- `sandbox/core/oso_core.py` gained a minimal stdlib-only RFC 6455 WebSocket server
  (`/ws`) broadcasting tag changes, `group`/`ts_us` on published tags, and a fix to
  `PUT /api/v1/tags/{id}` so it returns the actually-applied value instead of a
  partial response the UI couldn't merge correctly. Also fixed `_db_test()`'s DSN
  parser, which only recognized dotted-IPv4 hosts and so reported a false
  "connection refused" against the Database panel's own default DSN (`host=db ...`).

## Test plan
- [x] `docker compose up --build` from a clean `sandbox/` brings up db/core/nodered
      with no errors
- [x] Node-RED first boot installs the full palette and imports flows without the
      "missing node type" banner
- [x] I/O Tags page: live WebSocket updates (green dot), groups populated, "Updated"
      column populated, edit pencil works for text ids, type filter matches real
      data, boolean toggle stages until ✓, read-only tags show 🔒
- [x] `GET /api/v1/database` reports the real MariaDB connection status correctly

---
This PR is submitted under and accepts the OSOlogic CLA (CLA.md).
